### PR TITLE
v1.2.0: replace connect w/ parseurl; fix license

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var connect = require("connect"),
+var parseUrl = require("parseurl"),
 	_ = require("underscore");
 
 module.exports = createPathCondition;
@@ -20,8 +20,7 @@ function createPathCondition(path, options) {
 	var pathRE = createRE(path, options);
 
 	return function(req) {
-		// @TODO Maybe remove `connect` dependency
-		var reqPath = connect.utils.parseUrl(req).pathname,
+		var reqPath = parseUrl(req).pathname,
 			results = pathRE.exec(reqPath),
 			isMatch = !! results;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-route",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "HTTP routing with a nestable functional style",
   "main": "index.js",
   "scripts": {
@@ -13,14 +13,13 @@
   "keywords": [
     "http",
     "route",
-    "connect",
     "request",
     "router"
   ],
   "author": "Parsha Pourkhomami",
-  "license": "Public Domain",
+  "license": "MIT",
   "dependencies": {
-    "connect": "~2.8.0",
+    "parseurl": "^1.3.2",
     "underscore": "~1.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This change replaces the `connect` module with `parseurl` to resolve Issue #1  (connect security vulnerabilities). I didn't really need to update the module license, but doing so removes all warnings when installing the module. I also updated the version. All tests passing and tests in my other projects dependent on `http-route` are passing.