### PR TITLE
1.2.0: upgrade connect & require only for dev

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var connect = require("connect"),
+var parseUrl = require("parseurl"),
 	_ = require("underscore");
 
 module.exports = createPathCondition;
@@ -20,8 +20,7 @@ function createPathCondition(path, options) {
 	var pathRE = createRE(path, options);
 
 	return function(req) {
-		// @TODO Maybe remove `connect` dependency
-		var reqPath = connect.utils.parseUrl(req).pathname,
+		var reqPath = parseUrl(req).pathname,
 			results = pathRE.exec(reqPath),
 			isMatch = !! results;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-route",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "HTTP routing with a nestable functional style",
   "main": "index.js",
   "scripts": {
@@ -18,13 +18,14 @@
     "router"
   ],
   "author": "Parsha Pourkhomami",
-  "license": "Public Domain",
+  "license": "MIT",
   "dependencies": {
-    "connect": "~2.8.0",
+    "parseurl": "~1.3.2",
     "underscore": "~1.4.4"
   },
   "devDependencies": {
     "tape": "~1.0.4",
-    "concat-stream": "~1.0.0"
+    "concat-stream": "~1.0.0",
+    "connect": "~3.6.5"
   }
 }


### PR DESCRIPTION
This changes adds a dependency on the `parseurl` module for path parsing, which was formerly provided by the `connect` module. The `connect` module has been upgraded to address security vulnerabilities in package dependencies.  The `connect` module is also now only required for development.

I didn't really need to update the module license, but doing so removes all warnings when installing the module. I also updated the version.

Resolves #1 